### PR TITLE
fix argument order for array

### DIFF
--- a/src/language/seq.md
+++ b/src/language/seq.md
@@ -20,11 +20,11 @@ hacspec. Instead, you have to declare nominally at the top-level new array types
 for a specific cell content and size with:
 
 ```rust, noplaypen
-array!(FooArray, u8, 64);
+array!(FooArray, 64, u8);
 // This declares type FooArray as an array of u8 of size 64
 bytes!(BarArray, 64);
 // bytes! is a specialized version of array! with secret bytes
-array!(BazArray, u8, 64, type_for_indexes:BazIndex);
+array!(BazArray, 64, u8, type_for_indexes:BazIndex);
 // The additional argument type_for_indexes defines an alias of usize
 // intended to spot which usizes are used to index BazArray (useful for
 // verification)

--- a/src/language/syntax.md
+++ b/src/language/syntax.md
@@ -2,7 +2,7 @@
 
 ```
 P ::= [i]\*                     Program items
-i ::= array!(t, μ, n)           Array type declaration where n is a natural number
+i ::= array!(t, n, μ)           Array type declaration where n is a natural number
     | nat_mod!(t, n)            Modular integer
     | fn f([d]+) -> μ b         Function declaration
     | type t = enum { [c(μ)]+ } Enum declaration (with constructors)


### PR DESCRIPTION
i suppose the correct way to use the array macro is
```
array!(FooArray, 64, u8);
```

and not
```
array!(FooArray, u8, 64);
```